### PR TITLE
Make user-facing API typesafe

### DIFF
--- a/Data/RoundRobin.hs
+++ b/Data/RoundRobin.hs
@@ -1,6 +1,12 @@
-module Data.RoundRobin where
+module Data.RoundRobin
+    ( RoundRobin
+    , newRoundRobin
+    , select
+    , set
+    ) where
 
 import Data.IORef
+import Data.List.NonEmpty (NonEmpty(..))
 
 -- | A simple round-robin table
 -- useful for selecting resource using round-robin fashion.
@@ -10,16 +16,14 @@ newtype RoundRobin a = RoundRobin (IORef [a]) deriving Eq
 --
 -- If list is empty, an error will be raised.
 -- will use 'NonEmpty' in future(ghc 8 are widely used).
-newRoundRobin :: [a] -> IO (RoundRobin a)
-newRoundRobin xs =
-    if null xs
-    then error "can't create an empty RoundRobin"
-    else newIORef (cycle xs) >>= return . RoundRobin
+newRoundRobin :: NonEmpty a -> IO (RoundRobin a)
+newRoundRobin (x :| xs) =
+    newIORef (cycle (x:xs)) >>= return . RoundRobin
 
 -- | select an item from round-robin table.
 select :: RoundRobin a -> IO a
 select (RoundRobin ref) = atomicModifyIORef' ref (\ (a:as) -> (as, a))
 
 -- | set a new round-robin table.
-set :: RoundRobin a -> [a] -> IO ()
-set (RoundRobin ref) xs = atomicModifyIORef' ref (const (cycle xs , ()))
+set :: RoundRobin a -> NonEmpty a -> IO ()
+set (RoundRobin ref) (x :| xs) = atomicModifyIORef' ref (const (cycle (x:xs) , ()))

--- a/roundRobin.cabal
+++ b/roundRobin.cabal
@@ -24,5 +24,19 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base >=4.6 && <5.0
+                     , semigroups
   -- hs-source-dirs:      
+  default-language:    Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: test
+  build-depends:
+      roundRobin
+    , base
+    , QuickCheck
+    , tasty
+    , tasty-quickcheck
+    , semigroups
   default-language:    Haskell2010

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,35 @@
+module Main
+    ( main
+    ) where
+
+import Data.RoundRobin
+
+import Control.Monad
+import Data.List.NonEmpty as NE
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.QuickCheck.Monadic
+
+
+main :: IO ()
+main = defaultMain $ testGroup "Data.RoundRobin"
+  [ selectTests
+  ]
+
+
+selectTests :: TestTree
+selectTests = testGroup "select"
+  [ testProperty "can always produce an element" $ \(NonEmpty (x:xs)) -> monadicIO $ do
+      let ne = x :| xs :: NonEmpty ()
+      rr <- run (newRoundRobin ne)
+      let len = NE.length ne
+      results <- run (replicateM (NE.length ne + 1) (select rr))
+      assert (all (== ()) results)
+  , testProperty "returns items in the order supplied" $ \(NonEmpty orig@(x:xs)) -> monadicIO $ do
+     let ne = x :| xs :: NonEmpty ()
+     rr <- run (newRoundRobin ne)
+     let len = NE.length ne
+     results <- run (replicateM (NE.length ne) (select rr))
+     assert (results == orig)
+  ]
+


### PR DESCRIPTION
It wasn't too much harder to make it impossible to violate the main
invariant of the roundrobin (no empty lists). In accordance with this, I
also used an explicit export list so the invariants couldn't be violated
that way.

BTW this was an idea for the sniffing API you PRed to bloodhound so we wouldn't have to use partial functions.
